### PR TITLE
Feature/category navigation highlight

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import ProductCard from '@/components/product-card'
 import { useState } from 'react'
 
 export default function Home() {
+	const [activeCategory, setActiveCategory] = useState('Комнатные растения')
 	const [filtersVisible, setFiltersVisible] = useState(false)
 	const totalPages = 4 // временное решение
 	const currentPage = 1 // временное решение
@@ -37,20 +38,19 @@ export default function Home() {
 						filtersVisible ? 'block' : 'hidden'
 					} lg:block bg-gray-50 w-full h-full lg:w-1/4 p-4 lg:p-6 rounded-lg shadow-sm`}
 				>
-					<h2 className='text-2xl font-semibold text-gray-800 mb-6'>
-						Категории
-					</h2>
+					<h2 className='text-2xl font-semibold text-gray-800 mb-6'>Категории</h2>
 					{categories.map((category, index) => (
 						<div
 							key={index}
-							className='flex justify-between items-center text-gray-700 group cursor-pointer hover:text-green-custom transition-colors mb-2'
+							className={`flex justify-between items-center text-gray-700 group cursor-pointer mb-2 px-3 py-2 rounded-lg transition-colors ${
+								activeCategory === category.name
+									? 'bg-green-100 text-green-custom font-semibold'
+									: 'hover:bg-gray-100 hover:text-green-custom'
+							}`}
+							onClick={() => setActiveCategory(category.name)}
 						>
-							<span className='group-hover:text-green-custom transition-colors'>
-								{category.name}
-							</span>
-							<span className='text-gray-500 group-hover:text-green-custom transition-colors'>
-								({category.count})
-							</span>
+							<span>{category.name}</span>
+							<span className='text-gray-500'>{`(${category.count})`}</span>
 						</div>
 					))}
 
@@ -64,10 +64,7 @@ export default function Home() {
 								className='w-full accent-green-custom'
 							/>
 							<p className='text-gray-700 text-sm'>
-								Цена:{' '}
-								<span className='text-green-custom'>
-									250 руб. - 15 000 руб.
-								</span>
+								Цена: <span className='text-green-custom'>250 руб. - 15 000 руб.</span>
 							</p>
 						</div>
 					</div>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,4 +1,4 @@
-'use client';
+'use client'
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
@@ -12,50 +12,59 @@ export default function Header() {
 
 	const navLinks = [
 		{ href: '/', label: 'Главная' },
-		{ href: '/products', label: 'Товары' },
+		{ href: '/product', label: 'Товары' },
 		{ href: '/care', label: 'Уход' },
 		{ href: '/blog', label: 'Блог' },
 	]
 
 	return (
-		<header className=''>
-			<div className='container flex justify-between items-center py-4  border-b border-green-custom-transparent'>
+		<header>
+			<div className='container flex justify-between items-center py-4 border-b border-green-custom-transparent'>
 				<div className='flex items-center'>
 					<Link href='/' className='flex items-center'>
-						<Image src={logo} className="w-auto h-auto" alt='logo' />
+						<Image src={logo} className='w-auto h-auto' alt='logo' />
 					</Link>
 				</div>
 
-				<nav className="hidden md:flex space-x-11">
-          {navLinks.map((link) => (
-            <Link
-              key={link.href}
-              href={link.href}
-              className={`relative text-gray-700 hover:text-green-600 font-medium ${
-                pathname === link.href ? 'text-green-600' : ''
-              }`}
-            >
-              {link.label}
-              {pathname === link.href && (
-                <span className="absolute bottom-[-25px] left-0 right-0 h-[3px] bg-green-custom"></span>
-              )}
-            </Link>
-          ))}
-        </nav>
+				<nav className='hidden md:flex space-x-11'>
+					{navLinks.map(link => {
+						const isActive =
+							(link.href === '/' && pathname === '/') || 
+							(link.href === '/product' && pathname.startsWith('/product')) 
 
-				<div className="flex items-center space-x-8">
-          <button className="text-gray-700 hover:text-green-600">
+						return (
+							<Link
+								key={link.href}
+								href={link.href === '/product' ? '/' : link.href} 
+								className={`relative text-gray-700 hover:text-green-600 font-medium ${
+									isActive ? 'text-green-600' : ''
+								}`}
+							>
+								{link.label}
+								{isActive && (
+									<span className='absolute bottom-[-25px] left-0 right-0 h-[3px] bg-green-custom'></span>
+								)}
+							</Link>
+						)
+					})}
+				</nav>
+
+				<div className='flex items-center space-x-8'>
+					<button className='text-gray-700 hover:text-green-600'>
 						<Image src={search} alt='search' />
-          </button>
+					</button>
 
-          <button className="text-gray-700 hover:text-green-600">
+					<button className='text-gray-700 hover:text-green-600'>
 						<Image src={basket} alt='basket' />
-          </button>
+					</button>
 
-          <Link href="/login" className="bg-green-custom text-white font-medium px-8 py-2 rounded-lg hover:bg-green-600">
-            Вход
-          </Link>
-        </div>
+					<Link
+						href='/login'
+						className='bg-green-custom text-white font-medium px-8 py-2 rounded-lg hover:bg-green-600'
+					>
+						Вход
+					</Link>
+				</div>
 			</div>
 		</header>
 	)


### PR DESCRIPTION
### Overview
This pull request introduces the functionality to highlight the selected category on the main page. The category "Комнатные растения" is initially highlighted by default, and users can now select other categories to see them highlighted.

### Key Changes
1. Added state management (`activeCategory`) to track the currently selected category.
2. Updated the `categories` filter list to apply specific styles (green background and font color) to the selected category.
3. Implemented a click handler to update the state when a user clicks on a category.
4. Ensured hover effects are applied to unselected categories for better user experience.

### Testing
- Verified that "Комнатные растения" is highlighted by default.
- Checked that selecting a different category highlights it correctly and removes the highlight from the previous one.
- Tested responsiveness to ensure functionality on various screen sizes.

### Next Steps
- Extend functionality to filter displayed products based on the selected category.
- Optimize performance when handling large datasets of categories and products.

Please review the changes and let me know if any additional updates are required.
